### PR TITLE
Add Uuv robot type parsing

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -127,6 +127,7 @@ pub struct URDFRobot {
 pub enum RobotType {
     Drone,
     NotDrone,
+    Uuv,
 }
 
 impl FromStr for RobotType {
@@ -136,6 +137,7 @@ impl FromStr for RobotType {
         match s.to_lowercase().as_str() {
             "drone" => Ok(RobotType::Drone),
             "notdrone" | "not_drone" | "not-drone" => Ok(RobotType::NotDrone),
+            "uuv" => Ok(RobotType::Uuv),
             _ => Err(format!("Invalid robot type: '{s}'")),
         }
     }


### PR DESCRIPTION
## Summary
- add `Uuv` variant to `RobotType`
- support parsing `"uuv"` in conversion implementations

## Testing
- `cargo check` *(fails: fast_ode requires nightly)*

------
https://chatgpt.com/codex/tasks/task_e_68881f0fdbd8832481996d28d2065a11