### PR TITLE
Add UUV descriptor and simulation

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -89,6 +89,12 @@ pub struct UAVStateUpdate {
 }
 
 #[derive(Event)]
+pub struct UuvStateUpdate {
+    pub handle: Handle<UrdfAsset>,
+    pub uuv_state: crate::uuv::UuvState,
+}
+
+#[derive(Event)]
 pub struct ControlMotors {
     pub handle: Handle<UrdfAsset>,
     pub velocities: Vec<f32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod drones;
 pub mod events;
 pub mod plugin;
 pub mod urdf_asset_loader;
+pub mod uuv;
 
 pub use plugin::*;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -21,10 +21,11 @@ use crate::{
         handle_control_thrusts, render_drone_rotors, simulate_drone, switch_drone_physics,
         ControlThrusts,
     },
+    uuv::simulate_uuv,
     events::{
         handle_control_motors, handle_despawn_robot, handle_load_robot, handle_spawn_robot,
         handle_wait_robot_loaded, ControlMotors, DespawnRobot, LoadRobot, RobotLoaded,
-        RobotSpawned, SensorsRead, SpawnRobot, UAVStateUpdate, WaitRobotLoaded,
+        RobotSpawned, SensorsRead, SpawnRobot, UAVStateUpdate, UuvStateUpdate, WaitRobotLoaded,
     },
     urdf_asset_loader::{self, UrdfAsset},
 };
@@ -48,7 +49,7 @@ where
     /// [`with_default_system_setup(false)`](Self::with_default_system_setup).
     pub fn get_systems(set: PhysicsSet) -> ScheduleConfigs<ScheduleSystem> {
         match set {
-            PhysicsSet::StepSimulation => ((switch_drone_physics, simulate_drone).chain())
+            PhysicsSet::StepSimulation => ((switch_drone_physics, simulate_drone, simulate_uuv).chain())
                 .in_set(PhysicsSet::StepSimulation)
                 .into_configs(),
             PhysicsSet::SyncBackend => (
@@ -94,6 +95,7 @@ impl Plugin for UrdfPlugin {
             .add_event::<RobotSpawned>()
             .add_event::<SensorsRead>()
             .add_event::<UAVStateUpdate>()
+            .add_event::<UuvStateUpdate>()
             .add_event::<SpawnRobot>()
             .add_event::<WaitRobotLoaded>()
             .init_asset::<urdf_asset_loader::UrdfAsset>();

--- a/src/uuv.rs
+++ b/src/uuv.rs
@@ -1,0 +1,94 @@
+use std::collections::VecDeque;
+
+use bevy::prelude::*;
+
+use crate::{events::UuvStateUpdate, URDFRobot};
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct HydrodynamicProperties {
+    pub mass: f32,
+    pub buoyancy: f32,
+    pub linear_drag: Vec3,
+    pub angular_drag: Vec3,
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct UuvState {
+    pub position: Vec3,
+    pub orientation: Quat,
+    pub linear_velocity: Vec3,
+    pub angular_velocity: Vec3,
+}
+
+#[derive(Component, Debug, Clone)]
+pub struct UuvDescriptor {
+    pub hydrodynamic_props: HydrodynamicProperties,
+    pub thrust_force: Vec3,
+    pub thrust_torque: Vec3,
+    pub state: UuvState,
+    pub(crate) state_log: VecDeque<UuvState>,
+}
+
+impl Default for UuvDescriptor {
+    fn default() -> Self {
+        Self {
+            hydrodynamic_props: HydrodynamicProperties {
+                mass: 1.0,
+                buoyancy: 0.0,
+                linear_drag: Vec3::splat(0.1),
+                angular_drag: Vec3::splat(0.1),
+            },
+            thrust_force: Vec3::ZERO,
+            thrust_torque: Vec3::ZERO,
+            state: UuvState::default(),
+            state_log: VecDeque::new(),
+        }
+    }
+}
+
+impl UuvDescriptor {
+    fn push_state(&mut self, state: UuvState) {
+        self.state = state;
+        if self.state_log.len() >= 30 {
+            self.state_log.pop_front();
+        }
+        self.state_log.push_back(state);
+    }
+}
+
+pub(crate) fn simulate_uuv(
+    mut q_uuvs: Query<(&mut Transform, &URDFRobot, &mut UuvDescriptor)>,
+    time: Res<Time>,
+    mut ew_state: EventWriter<UuvStateUpdate>,
+) {
+    for (mut transform, robot, mut descriptor) in q_uuvs.iter_mut() {
+        let dt = time.delta_secs();
+        let props = descriptor.hydrodynamic_props;
+        let mut state = descriptor.state;
+
+        let buoyancy_force = Vec3::new(0.0, props.buoyancy, 0.0);
+        let drag_force = props.linear_drag * state.linear_velocity;
+        let total_force = descriptor.thrust_force + buoyancy_force - drag_force;
+        let acceleration = total_force / props.mass;
+        state.linear_velocity += acceleration * dt;
+        state.position += state.linear_velocity * dt;
+
+        let drag_torque = props.angular_drag * state.angular_velocity;
+        let total_torque = descriptor.thrust_torque - drag_torque;
+        let angular_acc = total_torque / props.mass;
+        state.angular_velocity += angular_acc * dt;
+        state.orientation = state.orientation
+            * Quat::from_rotation_x(state.angular_velocity.x * dt)
+            * Quat::from_rotation_y(state.angular_velocity.y * dt)
+            * Quat::from_rotation_z(state.angular_velocity.z * dt);
+
+        descriptor.push_state(state);
+        *transform = Transform::from_translation(state.position).with_rotation(state.orientation);
+
+        ew_state.write(UuvStateUpdate {
+            handle: robot.handle.clone(),
+            uuv_state: state,
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- support underwater vehicles with `UuvDescriptor`
- emit `UuvStateUpdate` events
- simulate UUV state each frame
- register new event/system in the plugin

## Testing
- `RUSTC_BOOTSTRAP=1 cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6888266b83288324ba822e5c3747a98e