### PR TITLE
Add UUV descriptor support

### DIFF
--- a/examples/quadrotor.rs
+++ b/examples/quadrotor.rs
@@ -104,6 +104,7 @@ fn start_simulation(
             parent_entity: Some(q_crazflie.iter().last().unwrap().0),
             robot_type: RobotType::Drone,
             drone_descriptor: event.drone_descriptor.clone(),
+            uuv_descriptor: event.uuv_descriptor.clone(),
         });
         state.set(AppState::Simulation);
         commands.insert_resource(UrdfRobotHandle(Some(event.handle.clone())));
@@ -206,5 +207,6 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
             translation_shift: Some(Vec3::new(0.0, 1.0, 0.0)),
         },
         drone_descriptor: None,
+        uuv_descriptor: None,
     });
 }

--- a/examples/quadruped.rs
+++ b/examples/quadruped.rs
@@ -82,6 +82,7 @@ fn start_simulation(
             parent_entity: None,
             robot_type: RobotType::NotDrone,
             drone_descriptor: None,
+            uuv_descriptor: None,
         });
         state.set(AppState::Simulation);
         commands.insert_resource(UrdfRobotHandle(Some(event.handle.clone())));
@@ -214,5 +215,6 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
         },
         marker: None,
         drone_descriptor: None,
+        uuv_descriptor: None,
     });
 }


### PR DESCRIPTION
## Summary
- support `RobotType::Uuv` in robot spawning
- parse thruster positions from URDF when none provided
- attach `UuvDescriptor` and spawn thruster entities

## Testing
- `cargo check` *(fails: build cancelled due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_68882c89cfa483248342bae310cc5342