### PR TITLE
Add UUV example with thruster control

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,23 @@ pub struct ControlThrusts {
 }
 ```
 
+#### Thruster Control (UUVs)
+
+For underwater vehicles:
+
+```rust
+#[derive(Event)]
+pub struct ControlThrusters {
+    pub handle: Handle<UrdfAsset>,
+    pub thrusts: Vec<f32>,
+}
+```
+
 ### Robot Types
 
 - `RobotType::NotDrone` - Ground vehicles, quadrupeds, manipulators
 - `RobotType::Drone` - Aerial vehicles with thrust-based control
+- `RobotType::Uuv` - Underwater vehicles with thruster control
 
 ## Examples
 
@@ -137,8 +150,11 @@ Run the included examples to see the plugin in action:
 # Drone simulation
 cargo run --example quadrotor --release
 
-# Quadruped robot simulation  
+# Quadruped robot simulation
 cargo run --example quadruped --release
+
+# Underwater vehicle simulation
+cargo run --example uuv --release
 ```
 
 ## URDF Requirements

--- a/assets/uuvs/simple_uuv.urdf
+++ b/assets/uuvs/simple_uuv.urdf
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<robot name="simple_uuv">
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1.0"/>
+      <inertia ixx="0.1" ixy="0" ixz="0" iyy="0.1" iyz="0" izz="0.1"/>
+    </inertial>
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.2"/>
+      </geometry>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <box size="0.2 0.2 0.2"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="thruster_front">
+    <inertial>
+      <origin xyz="0.2 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
+  <joint name="thruster_front_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="thruster_front"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <link name="thruster_back">
+    <inertial>
+      <origin xyz="-0.2 0 0" rpy="0 0 0"/>
+      <mass value="0.01"/>
+      <inertia ixx="0.01" ixy="0" ixz="0" iyy="0.01" iyz="0" izz="0.01"/>
+    </inertial>
+  </link>
+  <joint name="thruster_back_joint" type="fixed">
+    <parent link="base_link"/>
+    <child link="thruster_back"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+</robot>

--- a/examples/uuv.rs
+++ b/examples/uuv.rs
@@ -1,0 +1,124 @@
+use bevy::{
+    color::palettes::css::WHITE,
+    input::common_conditions::input_toggle_active,
+    prelude::*,
+};
+use bevy_flycam::prelude::*;
+use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
+use bevy_inspector_egui::bevy_egui::EguiPlugin;
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_obj::ObjPlugin;
+use bevy_rapier3d::prelude::*;
+use bevy_stl::StlPlugin;
+use bevy_urdf::events::{ControlThrusters, LoadRobot, RapierOption, RobotLoaded, SpawnRobot};
+use bevy_urdf::plugin::{RobotType, UrdfPlugin};
+use bevy_urdf::urdf_asset_loader::UrdfAsset;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            DefaultPlugins,
+            StlPlugin,
+            ObjPlugin,
+            FlyCameraPlugin {
+                spawn_camera: true,
+                grab_cursor_on_startup: true,
+            },
+            RapierPhysicsPlugin::<NoUserData>::default(),
+            UrdfPlugin::default().with_default_system_setup(true),
+            EguiPlugin {
+                enable_multipass_for_primary_context: true,
+            },
+            InfiniteGridPlugin,
+            WorldInspectorPlugin::default().run_if(input_toggle_active(false, KeyCode::Escape)),
+        ))
+        .init_state::<AppState>()
+        .insert_resource(MovementSettings { move_speed: Vec3::ONE * 3.0 })
+        .insert_resource(MouseSettings {
+            invert_horizontal: false,
+            invert_vertical: false,
+            mouse_sensitivity: 0.00012,
+            lock_cursor_to_middle: false,
+        })
+        .insert_resource(ClearColor(Color::linear_rgb(1.0, 1.0, 1.0)))
+        .insert_resource(UrdfRobotHandle(None))
+        .add_systems(Startup, setup)
+        .add_systems(Update, control_thrusters)
+        .add_systems(Update, start_simulation.run_if(in_state(AppState::Loading)))
+        .run();
+}
+
+#[derive(Resource)]
+struct UrdfRobotHandle(Option<Handle<UrdfAsset>>);
+
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash, States)]
+enum AppState {
+    #[default]
+    Loading,
+    Simulation,
+}
+
+fn start_simulation(
+    mut commands: Commands,
+    mut er_robot_loaded: EventReader<RobotLoaded>,
+    mut ew_spawn_robot: EventWriter<SpawnRobot>,
+    mut state: ResMut<NextState<AppState>>,
+) {
+    for event in er_robot_loaded.read() {
+        ew_spawn_robot.write(SpawnRobot {
+            handle: event.handle.clone(),
+            mesh_dir: event.mesh_dir.clone(),
+            parent_entity: None,
+            robot_type: RobotType::Uuv,
+            drone_descriptor: None,
+            uuv_descriptor: event.uuv_descriptor.clone(),
+        });
+        state.set(AppState::Simulation);
+        commands.insert_resource(UrdfRobotHandle(Some(event.handle.clone())));
+    }
+}
+
+fn control_thrusters(
+    robot_handle: Res<UrdfRobotHandle>,
+    mut ew_control_thrusters: EventWriter<ControlThrusters>,
+) {
+    if let Some(handle) = robot_handle.0.clone() {
+        ew_control_thrusters.write(ControlThrusters {
+            handle,
+            thrusts: vec![1.0, 1.0],
+        });
+    }
+}
+
+#[allow(deprecated)]
+fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
+    commands.insert_resource(AmbientLight {
+        color: WHITE.into(),
+        brightness: 300.0,
+        ..default()
+    });
+
+    commands.spawn((
+        InfiniteGridBundle {
+            transform: Transform::from_xyz(0.0, -1.0, 0.0),
+            ..default()
+        },
+        RigidBody::Fixed,
+        Collider::cuboid(900., 0.05, 900.),
+    ));
+
+    ew_load_robot.send(LoadRobot {
+        robot_type: RobotType::Uuv,
+        urdf_path: "uuvs/simple_uuv.urdf".to_string(),
+        mesh_dir: "assets/uuvs/".to_string(),
+        rapier_options: RapierOption {
+            interaction_groups: None,
+            translation_shift: Some(Vec3::new(0.0, 1.0, 0.0)),
+            create_colliders_from_visual_shapes: false,
+            create_colliders_from_collision_shapes: true,
+        },
+        marker: None,
+        drone_descriptor: None,
+        uuv_descriptor: None,
+    });
+}


### PR DESCRIPTION
## Summary
- add a simple UUV URDF example
- add an example demonstrating thruster control
- document `RobotType::Uuv` and the `ControlThrusters` event in README

## Testing
- `cargo +nightly check --examples`

------
https://chatgpt.com/codex/tasks/task_e_688831e60ca08324a772ada658d18cd9