### PR TITLE
Add MapTerrainPlugin module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod drones;
 pub mod events;
+pub mod map_terrain;
 pub mod plugin;
 pub mod urdf_asset_loader;
 pub mod uuv;
 
+pub use map_terrain::*;
 pub use plugin::*;
 
 pub use uav;

--- a/src/map_terrain.rs
+++ b/src/map_terrain.rs
@@ -1,0 +1,28 @@
+use bevy::prelude::*;
+
+#[derive(Resource, Clone)]
+pub struct MapConfig {
+    pub reference_lat: f64,
+    pub reference_lon: f64,
+    pub min_zoom: u8,
+    pub max_zoom: u8,
+    pub tile_source_url: String,
+    pub cache_dir: String,
+    pub tile_radius: u32,
+}
+
+pub struct MapTerrainPlugin {
+    pub config: MapConfig,
+}
+
+impl MapTerrainPlugin {
+    pub fn new(config: MapConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Plugin for MapTerrainPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(self.config.clone());
+    }
+}


### PR DESCRIPTION
## Summary
- add new `map_terrain` module with `MapConfig` and `MapTerrainPlugin`
- export the map terrain plugin from the library

## Testing
- `cargo +nightly check --lib`


------
https://chatgpt.com/codex/tasks/task_e_688844e86b8883249f8144bc39566ad7