### PR TITLE
Add heightmap terrain support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ roxmltree = "0.20"
 queues = "1.0.2"
 ehttp = "0.5"
 crossbeam-channel = "0.5"
+image = "0.24"
 
 [dev-dependencies]
 bevy = { version = "0.16", default-features = false, features = [

--- a/src/map_terrain.rs
+++ b/src/map_terrain.rs
@@ -2,6 +2,7 @@ use bevy::prelude::Plane3d;
 use bevy::prelude::*;
 use crossbeam_channel::{Receiver, Sender};
 use ehttp::Request;
+use image;
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
@@ -14,6 +15,12 @@ pub struct MapConfig {
     /// List of `(zoom, radius)` pairs sorted from highest zoom to lowest
     pub zoom_levels: Vec<(u8, u32)>,
     pub tile_source_url: String,
+    /// Optional source for per-tile heightmaps. `{z}`, `{x}` and `{y}` tokens
+    /// will be replaced with tile coordinates. Can be a local file path or a
+    /// remote URL.
+    pub heightmap_source_url: Option<String>,
+    /// Scale factor applied to heightmap values when generating terrain.
+    pub height_scale: f32,
     pub cache_dir: String,
     /// distance between zoom layers along the Y axis
     pub z_layer: f32,
@@ -50,7 +57,8 @@ pub struct TileResponse {
     pub z: u8,
     pub x: u32,
     pub y: u32,
-    pub bytes: Option<Vec<u8>>,
+    pub image_bytes: Option<Vec<u8>>,
+    pub height_bytes: Option<Vec<u8>>,
 }
 
 #[derive(Resource, Default)]
@@ -143,6 +151,10 @@ fn tile_path(z: u8, x: u32, y: u32) -> String {
     format!("assets/tiles/{z}/{x}/{y}.png")
 }
 
+fn heightmap_path(z: u8, x: u32, y: u32) -> String {
+    format!("assets/heightmaps/{z}/{x}/{y}.png")
+}
+
 fn tile_to_lon(z: u8, x: u32) -> f64 {
     let n = 2f64.powi(z as i32);
     x as f64 / n * 360.0 - 180.0
@@ -152,6 +164,66 @@ fn tile_to_lat(z: u8, y: u32) -> f64 {
     let n = 2f64.powi(z as i32);
     let lat_rad = f64::atan(f64::sinh(std::f64::consts::PI * (1.0 - 2.0 * y as f64 / n)));
     lat_rad.to_degrees()
+}
+
+fn heightmap_to_mesh(
+    img: &image::GrayImage,
+    width: f32,
+    height: f32,
+    scale: f32,
+) -> Mesh {
+    use bevy::render::mesh::{Indices, PrimitiveTopology};
+
+    let w = img.width() as usize;
+    let h = img.height() as usize;
+    let dx = width / (w as f32 - 1.0);
+    let dz = height / (h as f32 - 1.0);
+
+    let mut positions = Vec::with_capacity(w * h);
+    let mut normals = Vec::with_capacity(w * h);
+    let mut uvs = Vec::with_capacity(w * h);
+
+    let get_height = |i: usize, j: usize| -> f32 {
+        let pixel = img.get_pixel(i as u32, j as u32)[0] as f32 / 255.0;
+        pixel * scale
+    };
+
+    for j in 0..h {
+        for i in 0..w {
+            let x = i as f32 * dx - width / 2.0;
+            let z = j as f32 * dz - height / 2.0;
+            let y = get_height(i, j);
+
+            let left = if i > 0 { get_height(i - 1, j) } else { y };
+            let right = if i + 1 < w { get_height(i + 1, j) } else { y };
+            let down = if j > 0 { get_height(i, j - 1) } else { y };
+            let up = if j + 1 < h { get_height(i, j + 1) } else { y };
+
+            let normal = Vec3::new(left - right, 2.0, down - up).normalize();
+
+            positions.push([x, y, z]);
+            normals.push(normal.to_array());
+            uvs.push([i as f32 / (w as f32 - 1.0), 1.0 - j as f32 / (h as f32 - 1.0)]);
+        }
+    }
+
+    let mut indices = Vec::with_capacity((w - 1) * (h - 1) * 6);
+    for j in 0..h - 1 {
+        for i in 0..w - 1 {
+            let a = (j * w + i) as u32;
+            let b = a + 1;
+            let c = a + w as u32;
+            let d = c + 1;
+            indices.extend_from_slice(&[a, b, c, b, d, c]);
+        }
+    }
+
+    let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+    mesh.set_indices(Some(Indices::U32(indices)));
+    mesh
 }
 
 fn spawn_tile(
@@ -180,8 +252,26 @@ fn spawn_tile(
 
     let width = (east_world.x - west_world.x).abs();
     let height = (north_world.y - south_world.y).abs();
+    let mut mesh = None;
+    if let Some(template) = &config.heightmap_source_url {
+        let path = template
+            .replace("{z}", &z.to_string())
+            .replace("{x}", &x.to_string())
+            .replace("{y}", &y.to_string());
+        #[cfg(not(target_arch = "wasm32"))]
+        if Path::new(&path).exists() {
+            if let Ok(img) = image::open(&path) {
+                mesh = Some(heightmap_to_mesh(
+                    &img.into_luma8(),
+                    width,
+                    height,
+                    config.height_scale,
+                ));
+            }
+        }
+    }
 
-    let mesh = meshes.add(Plane3d::default().mesh().size(width, height));
+    let mesh_handle = meshes.add(mesh.unwrap_or_else(|| Plane3d::default().mesh().size(width, height)));
     let path = tile_path(z, x, y);
     let handle: Handle<Image> = asset_server.load(path.as_str());
     let material = materials.add(StandardMaterial {
@@ -192,7 +282,7 @@ fn spawn_tile(
     });
 
     commands.spawn((
-        Mesh3d(mesh),
+        Mesh3d(mesh_handle.clone()),
         MeshMaterial3d(material),
         Transform::from_xyz(center.x, config.z_layer * z as f32, center.y),
         MapTile { z, x, y },
@@ -242,14 +332,43 @@ fn download_tiles(
             .replace("{x}", &req.x.to_string())
             .replace("{y}", &req.y.to_string());
 
+        let hm_url = config
+            .heightmap_source_url
+            .as_ref()
+            .map(|u| {
+                u.replace("{z}", &req.z.to_string())
+                    .replace("{x}", &req.x.to_string())
+                    .replace("{y}", &req.y.to_string())
+            });
+
         let tx = cache.sender.clone();
         let z = req.z;
         let x = req.x;
         let y = req.y;
 
         ehttp::fetch(Request::get(url), move |result| {
-            let bytes = result.ok().map(|r| r.bytes);
-            let _ = tx.send(TileResponse { z, x, y, bytes });
+            let image_bytes = result.ok().map(|r| r.bytes);
+            if let Some(hurl) = hm_url {
+                let tx2 = tx.clone();
+                ehttp::fetch(Request::get(hurl), move |hres| {
+                    let height_bytes = hres.ok().map(|r| r.bytes);
+                    let _ = tx2.send(TileResponse {
+                        z,
+                        x,
+                        y,
+                        image_bytes: image_bytes.clone(),
+                        height_bytes,
+                    });
+                });
+            } else {
+                let _ = tx.send(TileResponse {
+                    z,
+                    x,
+                    y,
+                    image_bytes,
+                    height_bytes: None,
+                });
+            }
         });
     }
 }
@@ -265,13 +384,30 @@ fn process_downloads(
     while let Ok(res) = cache.receiver.try_recv() {
         let key = (res.z, res.x, res.y);
         cache.in_flight.remove(&key);
-        if let Some(bytes) = res.bytes {
+        if let Some(bytes) = res.image_bytes {
             #[cfg(not(target_arch = "wasm32"))]
             {
                 let path = tile_path(res.z, res.x, res.y);
                 if let Some(dir) = Path::new(&path).parent() {
                     if std::fs::create_dir_all(dir).is_ok() {
                         let _ = std::fs::write(&path, &bytes);
+                    }
+                }
+            }
+        }
+
+        if let Some(bytes) = res.height_bytes {
+            if let Some(template) = &config.heightmap_source_url {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let path = template
+                        .replace("{z}", &res.z.to_string())
+                        .replace("{x}", &res.x.to_string())
+                        .replace("{y}", &res.y.to_string());
+                    if let Some(dir) = Path::new(&path).parent() {
+                        if std::fs::create_dir_all(dir).is_ok() {
+                            let _ = std::fs::write(&path, &bytes);
+                        }
                     }
                 }
             }
@@ -364,6 +500,8 @@ mod tests {
             reference_lon: 10.0,
             zoom_levels: vec![(0, 0)],
             tile_source_url: String::new(),
+            heightmap_source_url: None,
+            height_scale: 1.0,
             cache_dir: String::new(),
             z_layer: 0.0,
         }


### PR DESCRIPTION
## Summary
- allow configuring a heightmap source URL
- generate terrain mesh from grayscale heightmap images
- fallback to flat quads when no heightmap data exists
- add `image` crate dependency

## Testing
- `cargo check --quiet` *(fails: `fast_ode` requires nightly)*

------
https://chatgpt.com/codex/tasks/task_e_68885d4beb0c83249f6156a6fa103045