### PR TITLE
Update UUV example with map terrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ cargo run --example quadrotor --release
 # Quadruped robot simulation
 cargo run --example quadruped --release
 
-# Underwater vehicle simulation
+# Underwater vehicle simulation with map terrain
 cargo run --example uuv --release
 ```
 

--- a/examples/uuv.rs
+++ b/examples/uuv.rs
@@ -4,7 +4,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_flycam::prelude::*;
-use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
+use bevy_urdf::{MapConfig, MapTerrainPlugin};
 use bevy_inspector_egui::bevy_egui::EguiPlugin;
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_obj::ObjPlugin;
@@ -29,7 +29,18 @@ fn main() {
             EguiPlugin {
                 enable_multipass_for_primary_context: true,
             },
-            InfiniteGridPlugin,
+            MapTerrainPlugin::new(MapConfig {
+                // Reference point roughly centered on the UUV example area
+                reference_lat: 47.6205,
+                reference_lon: -122.3493,
+                // Highest zoom first; radius in tiles around the UUV
+                zoom_levels: vec![(16, 1), (15, 2)],
+                tile_source_url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png".to_string(),
+                heightmap_source_url: None,
+                height_scale: 1.0,
+                cache_dir: "assets/tiles".to_string(),
+                z_layer: 0.0,
+            }),
             WorldInspectorPlugin::default().run_if(input_toggle_active(false, KeyCode::Escape)),
         ))
         .init_state::<AppState>()
@@ -97,15 +108,6 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
         brightness: 300.0,
         ..default()
     });
-
-    commands.spawn((
-        InfiniteGridBundle {
-            transform: Transform::from_xyz(0.0, -1.0, 0.0),
-            ..default()
-        },
-        RigidBody::Fixed,
-        Collider::cuboid(900., 0.05, 900.),
-    ));
 
     ew_load_robot.send(LoadRobot {
         robot_type: RobotType::Uuv,


### PR DESCRIPTION
## Summary
- use `MapTerrainPlugin` in `examples/uuv.rs`
- set Seattle reference coordinates with zoom settings
- document map terrain use in README

## Testing
- `cargo check --examples` *(fails: `fast_ode` requires nightly)*

------
https://chatgpt.com/codex/tasks/task_e_6888611b88e083249b54fd91f6ef6db7