### PR TITLE
Fix warnings and tile path handling

### DIFF
--- a/patches/fast_ode-1.0.0/src/lib.rs
+++ b/patches/fast_ode-1.0.0/src/lib.rs
@@ -83,11 +83,11 @@ impl<const N: usize> core::ops::Add<Coord<{ N }>> for Coord<{ N }> {
     }
 }
 
-#[cfg(dormand_prince_logging)]
+#[cfg(feature = "dormand_prince_logging")]
 macro_rules! log {
     ($($arg:tt)*) => (eprint!($($arg)*));
 }
-#[cfg(dormand_prince_logging)]
+#[cfg(feature = "dormand_prince_logging")]
 macro_rules! logln {
     () => (log!("\n"));
     ($($arg:tt)*) => ({
@@ -96,11 +96,11 @@ macro_rules! logln {
 }
 
 #[allow(unused_macros)]
-#[cfg(not(dormand_prince_logging))]
+#[cfg(not(feature = "dormand_prince_logging"))]
 macro_rules! log {
     ($($arg:tt)*) => {};
 }
-#[cfg(not(dormand_prince_logging))]
+#[cfg(not(feature = "dormand_prince_logging"))]
 macro_rules! logln {
     () => {
         log!("\n")

--- a/src/drones.rs
+++ b/src/drones.rs
@@ -502,7 +502,7 @@ fn multirotor_dynamics(
 
 pub(crate) fn render_drone_rotors(
     mut q_rotors: Query<(Entity, &ChildOf, &mut Transform, &DroneRotor)>,
-    mut q_bodies: Query<(Entity, &ChildOf, &mut Transform), Without<DroneRotor>>,
+    q_bodies: Query<(Entity, &ChildOf, &Transform), Without<DroneRotor>>,
 ) {
     let quat_fix = Quat::from_rotation_x(std::f32::consts::PI / 2.0);
     for (_, child_of, mut transform, rotor) in q_rotors.iter_mut() {


### PR DESCRIPTION
## Summary
- switch fast_ode logging cfg to feature-based checks
- update Bevy API usages and remove unused code
- separate asset vs cache paths for tile downloads
- fix unused mutable query in drone rendering

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6888b7e2fea483249edfb6e2d6210de6