### PR TITLE
Improve terrain tile download logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,7 @@ dependencies = [
  "ehttp",
  "env_logger",
  "image 0.24.9",
+ "log",
  "nalgebra",
  "queues",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ queues = "1.0.2"
 ehttp = "0.5"
 crossbeam-channel = "0.5"
 image = "0.24"
+log = "0.4"
 
 [patch.crates-io]
 fast_ode = { path = "patches/fast_ode-1.0.0" }


### PR DESCRIPTION
## Summary
- add `log` crate dependency
- add debug logging around tile and heightmap download success/failures
- record caching of downloaded resources

## Testing
- `cargo check -p bevy_urdf --lib --quiet`
- `cargo test --lib -- --nocapture --test-threads=1` *(failed: build aborted due to long compile time)*

------
https://chatgpt.com/codex/tasks/task_e_6888c0fe595483248cd51778514f97f8