### PR TITLE
Enable PNG feature in Bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/stillonearth/bevy_urdf"
 
 [dependencies]
 anyhow = "1.0"
-bevy = { version = "0.16", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.16", default-features = false, features = ["bevy_asset", "png"] }
 rapier3d-urdf = { version = "0.6.0", features = ["stl", "wavefront"] }
 rapier3d = { version = "0.25", features = ["serde-serialize"] }
 bevy_rapier3d = { version = "0.30", features = [
@@ -47,6 +47,7 @@ bevy = { version = "0.16", default-features = false, features = [
     "bevy_window",
     "tonemapping_luts",
     "x11",
+    "png",
 ] }
 bevy_flycam = { git = "https://github.com/kSDOT/bevy_flycam.git", rev = "a6f36a" }
 bevy-inspector-egui = "0.31"

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ cargo run --example quadruped --release
 cargo run --example uuv --release
 ```
 
+When using `MapTerrainPlugin` (for example in the `uuv` example), the Bevy `png`
+feature must be enabled so that PNG tile images can be loaded correctly.
+
 ## URDF Requirements
 
 Before using URDF files with this plugin:


### PR DESCRIPTION
## Summary
- enable PNG support for `bevy` in dependencies and dev-dependencies
- note PNG requirement in README for `MapTerrainPlugin`

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6888c880d97c8324b6bfa6fd30c58c32