### PR TITLE
Add camera angle controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the necessary plugins to your Bevy app:
 
 ```rust
 use bevy::prelude::*;
-use bevy_urdf::{UrdfPlugin, StlPlugin, ObjPlugin};
+use bevy_urdf::{UrdfPlugin, StlPlugin, ObjPlugin, CameraControlPlugin};
 
 fn main() {
     App::new()
@@ -40,6 +40,7 @@ fn main() {
             UrdfPlugin,
             StlPlugin,
             ObjPlugin,
+            CameraControlPlugin,
         ))
         .run();
 }
@@ -133,6 +134,18 @@ For underwater vehicles:
 pub struct ControlThrusters {
     pub handle: Handle<UrdfAsset>,
     pub thrusts: Vec<f32>,
+}
+```
+
+#### Camera Rotation
+
+Control the viewing angle of any active camera:
+
+```rust
+#[derive(Event)]
+pub struct RotateCamera {
+    pub delta_yaw: f32,
+    pub delta_pitch: f32,
 }
 ```
 

--- a/examples/quadruped.rs
+++ b/examples/quadruped.rs
@@ -8,11 +8,13 @@ use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_rapier3d::prelude::*;
 use bevy_stl::StlPlugin;
 
+use bevy::input::{keyboard::KeyCode, ButtonInput};
 use bevy_urdf::events::{ControlMotors, DespawnRobot, LoadRobot, RobotLoaded, SensorsRead};
 use bevy_urdf::events::{RapierOption, SpawnRobot};
 use bevy_urdf::plugin::RobotType;
 use bevy_urdf::plugin::UrdfPlugin;
 use bevy_urdf::urdf_asset_loader::UrdfAsset;
+use bevy_urdf::{CameraControlPlugin, RotateCamera};
 
 use rand::Rng;
 
@@ -36,6 +38,7 @@ fn main() {
             },
             InfiniteGridPlugin,
             WorldInspectorPlugin::default().run_if(input_toggle_active(false, KeyCode::Escape)),
+            CameraControlPlugin,
         ))
         .init_state::<AppState>()
         .insert_resource(MovementSettings {
@@ -59,6 +62,7 @@ fn main() {
                 check_rapier_state.after(robot_lifecycle),
             ),
         )
+        .add_systems(Update, camera_angle_input)
         .add_systems(Update, start_simulation.run_if(in_state(AppState::Loading)))
         .run();
 }
@@ -217,4 +221,31 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
         drone_descriptor: None,
         uuv_descriptor: None,
     });
+}
+
+fn camera_angle_input(
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+    mut ew_rotate: EventWriter<RotateCamera>,
+) {
+    let mut delta_yaw = 0.0;
+    let mut delta_pitch = 0.0;
+    let step = 0.05;
+    if keyboard_input.pressed(KeyCode::ArrowLeft) {
+        delta_yaw += step;
+    }
+    if keyboard_input.pressed(KeyCode::ArrowRight) {
+        delta_yaw -= step;
+    }
+    if keyboard_input.pressed(KeyCode::ArrowUp) {
+        delta_pitch += step;
+    }
+    if keyboard_input.pressed(KeyCode::ArrowDown) {
+        delta_pitch -= step;
+    }
+    if delta_yaw != 0.0 || delta_pitch != 0.0 {
+        ew_rotate.send(RotateCamera {
+            delta_yaw,
+            delta_pitch,
+        });
+    }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,34 @@
+use bevy::prelude::*;
+
+#[derive(Event, Default, Clone, Copy)]
+pub struct RotateCamera {
+    pub delta_yaw: f32,
+    pub delta_pitch: f32,
+}
+
+pub struct CameraControlPlugin;
+
+impl Plugin for CameraControlPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<RotateCamera>()
+            .add_systems(Update, apply_camera_rotation);
+    }
+}
+
+fn apply_camera_rotation(
+    mut query: Query<&mut Transform, With<Camera>>,
+    mut events: EventReader<RotateCamera>,
+) {
+    let mut total_yaw = 0.0;
+    let mut total_pitch = 0.0;
+    for ev in events.read() {
+        total_yaw += ev.delta_yaw;
+        total_pitch += ev.delta_pitch;
+    }
+    if total_yaw != 0.0 || total_pitch != 0.0 {
+        for mut transform in query.iter_mut() {
+            transform.rotate_y(total_yaw);
+            transform.rotate_local_x(total_pitch);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod camera;
 pub mod drones;
 pub mod events;
 pub mod map_terrain;
@@ -5,6 +6,7 @@ pub mod plugin;
 pub mod urdf_asset_loader;
 pub mod uuv;
 
+pub use camera::*;
 pub use map_terrain::*;
 pub use plugin::*;
 


### PR DESCRIPTION
## Summary
- add `CameraControlPlugin` with `RotateCamera` event
- document how to use the plugin in the README
- wire camera controls into examples

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6888cc79e0f083248a7b65c70f29fcca