### PR TITLE
Add GEBCO tile server

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,30 @@ cargo run --example uuv --release
 When using `MapTerrainPlugin` (for example in the `uuv` example), the Bevy `png`
 feature must be enabled so that PNG tile images can be loaded correctly.
 
+### Bathymetry Tiles and Starting Location
+
+`MapTerrainPlugin` works with any map tile service following the `{z}/{x}/{y}`
+pattern. To visualize underwater terrain, supply a bathymetry tile source and
+set the reference coordinates. The snippet below centers the map near
+`41.61906° N, 71.20932° W` using public GEBCO tiles:
+
+```rust
+MapTerrainPlugin::new(MapConfig {
+    reference_lat: 41.61906,
+    reference_lon: -71.20932,
+    zoom_levels: vec![(16, 1), (15, 2)],
+    tile_source_url: "https://tiles.gebco.net/tiles/{z}/{x}/{y}.png".to_string(),
+    heightmap_source_url: None,
+    height_scale: 1.0,
+    cache_dir: "assets/tiles".to_string(),
+    z_layer: 0.0,
+});
+```
+
+Replace the URL with your preferred bathymetry tile server. See the
+[GEBCO gridded bathymetry data](https://www.gebco.net/data-products/gridded-bathymetry-data)
+for details.
+
 ## URDF Requirements
 
 Before using URDF files with this plugin:

--- a/examples/uuv.rs
+++ b/examples/uuv.rs
@@ -30,12 +30,12 @@ fn main() {
                 enable_multipass_for_primary_context: true,
             },
             MapTerrainPlugin::new(MapConfig {
-                // Reference point roughly centered on the UUV example area
-                reference_lat: 47.6205,
-                reference_lon: -122.3493,
+                // Reference point for Newport Harbor (approx.)
+                reference_lat: 41.61906,
+                reference_lon: -71.20932,
                 // Highest zoom first; radius in tiles around the UUV
                 zoom_levels: vec![(16, 1), (15, 2)],
-                tile_source_url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png".to_string(),
+                tile_source_url: "https://tiles.gebco.net/tiles/{z}/{x}/{y}.png".to_string(),
                 heightmap_source_url: None,
                 height_scale: 1.0,
                 cache_dir: "assets/tiles".to_string(),


### PR DESCRIPTION
## Summary
- switch docs and UUV example to use GEBCO tiles from tiles.gebco.net
- note GEBCO bathymetry data reference in docs

## Testing
- `cargo test --no-run --quiet` *(fails to build in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6888d2decfe883249579df6b9bf59ea1